### PR TITLE
Utilize more scripts to handle candlepin branching

### DIFF
--- a/branch_project
+++ b/branch_project
@@ -14,6 +14,10 @@ for repo in $(./ensure_clean_git_checkouts "$@") ; do
 			bundle exec librarian-puppet install
 			git add .gitignore Puppetfile*
 			git commit --message "Pin Puppet modules for ${VERSION}"
+		elif [[ $repo == candlepin-packaging ]] ; then
+			sed -i "/candlepin_version/ s/'.\+'/'$VERSION'/" package_manifest.yaml
+			git add package_manifest.yaml
+			git commit --message "Set Candlepin version to ${VERSION}"
 		fi
 	)
 done

--- a/procedures/candlepin/branch.md.erb
+++ b/procedures/candlepin/branch.md.erb
@@ -1,21 +1,11 @@
-# Branch Packaging
-
-- [ ] Clone https://github.com/theforeman/candlepin-packaging
-- [ ] Check out most recent branch `rpm/< latest_version >`
-- [ ] Create a new branch for the version being added
-  - `git checkout -b rpm/<%= release %>`
-- [ ] Update `package_manifest.yaml` with <%= release %>
+- Branch packaging
+  - [ ] <%= rel_eng_script('branch_project') %>: `VERSION=<%= release %> PROJECT=candlepin ./branch_project`
+  - [ ] <%= rel_eng_script('branch_push') %>: `VERSION=<%= release %> PROJECT=candlepin ./branch_push`
 - [ ] Create project in copr `obal copr-project candlepin-staging-<%= release %>`
-- [ ] Push new branch to https://github.com/theforeman/candlepin-packaging
-
-# Update CI
-
-- [ ] Open a PR with the following updates:
-  - [ ] Add new vars file for the version being branched, [for example](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/vars/candlepin/4.4.groovy)
-  - [ ] Add <%= release %> to https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/yaml/includes/candlepin_versions.yaml.inc
-  - [ ] Add <%= release %> to https://github.com/theforeman/jenkins-jobs/blob/master/centos.org/jobs/candlepin-pipelines.yml
+- [ ] In [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) open a PR with the result of `./branch-candlepin <%= release %>`
 - Create new GPG key for release
   - [ ] <%= rel_eng_script('generate_gpg') %>: `VERSION=<%= release %> PROJECT=candlepin ./generate_gpg`
   - [ ] <%= rel_eng_script('export_gpg_private') %>: `VERSION=<%= release %> PROJECT=candlepin ./export_gpg_private`
   - [ ] <%= rel_eng_script('sign_gpg') %>: `VERSION=<%= release %> PROJECT=candlepin ./sign_gpg`
   - [ ] <%= rel_eng_script('upload_gpg') %>: `VERSION=<%= release %> PROJECT=candlepin ./upload_gpg`
+  - Update `releases/candlepin/<%= release %>/settings` and submit as a PR to [theforeman-rel-eng](https://github.com/theforeman/theforeman-rel-eng)

--- a/procedures/candlepin/release.md.erb
+++ b/procedures/candlepin/release.md.erb
@@ -1,10 +1,9 @@
 # Build Package
 
 - [ ] Acquire Candlepin SRPM for <%= release %>
-- [ ] Build into Copr
-  - `copr build @theforeman/candlepin-staging-<%= release %> <SRPM>`
+- [ ] Build into Copr: `copr build @theforeman/candlepin-staging-<%= release %> <SRPM>`
 - [ ] Sign RPMs
-  - [ ] VERSION=<%= release %> PROJECT=candlepin <%= rel_eng_script('generate_stage_repository') %>
-  - [ ] VERSION=<%= release %> PROJECT=candlepin <%= rel_eng_script('sign_stage_rpms') %>
-  - [ ] VERSION=<%= release %> PROJECT=candlepin <%= rel_eng_script('upload_stage_rpms') %>
-- [ ] [Run release pipeline](https://ci.theforeman.org/job/candlepin-<%= release %>-rpm-pipeline/)
+  - [ ] <%= rel_eng_script('generate_stage_repository') %>: `VERSION=<%= release %> PROJECT=candlepin ./generate_stage_repository`
+  - [ ] <%= rel_eng_script('sign_stage_rpms') %>: `VERSION=<%= release %> PROJECT=candlepin ./sign_stage_rpms`
+  - [ ] <%= rel_eng_script('upload_stage_rpms') %>: `VERSION=<%= release %> PROJECT=candlepin ./upload_stage_rpms`
+- [ ] Kick off the [release pipeline](https://ci.theforeman.org/job/candlepin-<%= release %>-rpm-pipeline/) by calling <%= rel_eng_script('release_pipeline') %>: `VERSION=<%= release %> PROJECT=candlepin ./release_pipeline`

--- a/releases/candlepin/settings
+++ b/releases/candlepin/settings
@@ -3,3 +3,6 @@ PASS_NAME_KEY="theforeman/releases/candlepin/$VERSION-key"
 SIGNER_NAME="Candlepin Automatic Signing Key"
 FOREMAN_VERSION='none'
 OSES='el8 el9'
+GIT_DEVELOP_BRANCH="rpm/develop"
+GIT_STABLE_BRANCH="rpm/${VERSION}"
+TAR_PROJECTS="candlepin-packaging"


### PR DESCRIPTION
This reuses the existing branch_project and branch_push scripts to handle candlepin-packaging's branching. branch_project is modified to update package_manifest.yaml as well as some setting files.

For CI it uses the branch-candlepin script inside the repository While also using the release_pipeline script to kick off Jenkins.

That last step depends on https://github.com/theforeman/jenkins-jobs/pull/484